### PR TITLE
fix: complete Litecoin-to-Marscoin rename for pip installability

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include LICENCE RELEASE-NOTES AUTHORS
 include README.md
-include electrum-ltc.desktop
+include electrum-mars.desktop
 include *.py
 include run_electrum
 recursive-include packages *.py
@@ -10,14 +10,14 @@ include contrib/requirements/requirements*.txt
 include contrib/deterministic-build/requirements*.txt
 include contrib/*.sh
 
-graft electrum_ltc
-prune electrum_ltc/tests
+graft electrum_mars
+prune electrum_mars/tests
 graft contrib/udev
 
-exclude electrum_ltc/*.so
-exclude electrum_ltc/*.so.0
-exclude electrum_ltc/*.dll
-exclude electrum_ltc/*.dylib
+exclude electrum_mars/*.so
+exclude electrum_mars/*.so.0
+exclude electrum_mars/*.dll
+exclude electrum_mars/*.dylib
 
 global-exclude __pycache__
 global-exclude *.py[co~]

--- a/electrum_mars/electrum-mars
+++ b/electrum_mars/electrum-mars
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+# -*- mode: python -*-
+#
+# Electrum - lightweight Bitcoin client
+# Copyright (C) 2011 thomasv@gitorious
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+import sys
+
+
+MIN_PYTHON_VERSION = "3.8.0"  # FIXME duplicated from setup.py
+_min_python_version_tuple = tuple(map(int, (MIN_PYTHON_VERSION.split("."))))
+
+
+if sys.version_info[:3] < _min_python_version_tuple:
+    sys.exit("Error: Electrum requires Python version >= %s..." % MIN_PYTHON_VERSION)
+
+
+import warnings
+import asyncio
+from typing import TYPE_CHECKING, Optional
+
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+is_pyinstaller = getattr(sys, 'frozen', False)
+is_android = 'ANDROID_DATA' in os.environ
+is_appimage = 'APPIMAGE' in os.environ
+# is_local: unpacked tar.gz but not pip installed, or git clone
+is_local = (not is_pyinstaller and not is_android and not is_appimage
+            and os.path.exists(os.path.join(script_dir, "electrum-mars.desktop")))
+is_git_clone = is_local and os.path.exists(os.path.join(script_dir, ".git"))
+
+if is_git_clone:
+    # developers should probably see all deprecation warnings.
+    warnings.simplefilter('default', DeprecationWarning)
+
+if is_local or is_android:
+    sys.path.insert(0, os.path.join(script_dir, 'packages'))
+
+if is_pyinstaller:
+    # Keep an open file handle for the binary that started us. On Windows, this
+    # prevents users from moving or renaming the exe file while running (doing which
+    # causes ImportErrors and other runtime failures). (see #4072)
+    _file = open(sys.executable, 'rb')
+
+
+def check_imports():
+    # pure-python dependencies need to be imported here for pyinstaller
+    try:
+        import dns
+        import certifi
+        import qrcode
+        import google.protobuf
+        import aiorpcx
+    except ImportError as e:
+        sys.exit(f"Error: {str(e)}. Try 'sudo python3 -m pip install <module-name>'")
+    if not ((0, 22, 0) <= aiorpcx._version < (0, 26)):
+        raise RuntimeError(f'aiorpcX version {aiorpcx._version} does not match required: 0.22.0<=ver<0.26')
+    # the following imports are for pyinstaller
+    from google.protobuf import descriptor
+    from google.protobuf import message
+    from google.protobuf import reflection
+    from google.protobuf import descriptor_pb2
+    # make sure that certificates are here
+    assert os.path.exists(certifi.where())
+
+
+if not is_android:
+    check_imports()
+
+
+sys._ELECTRUM_RUNNING_VIA_RUNELECTRUM = True  # used by logging.py
+
+from electrum_mars.logging import get_logger, configure_logging  # import logging submodule first
+from electrum_mars import util
+from electrum_mars import constants
+from electrum_mars import SimpleConfig
+from electrum_mars.wallet_db import WalletDB
+from electrum_mars.wallet import Wallet
+from electrum_mars.storage import WalletStorage
+from electrum_mars.util import print_msg, print_stderr, json_encode, json_decode, UserCancelled
+from electrum_mars.util import InvalidPassword
+from electrum_mars.commands import get_parser, known_commands, Commands, config_variables
+from electrum_mars import daemon
+from electrum_mars import keystore
+from electrum_mars.util import create_and_start_event_loop
+from electrum_mars.i18n import set_language
+
+if TYPE_CHECKING:
+    import threading
+
+    from electrum_mars.plugin import Plugins
+
+_logger = get_logger(__name__)
+
+
+# get password routine
+def prompt_password(prompt, confirm=True):
+    import getpass
+    password = getpass.getpass(prompt, stream=None)
+    if password and confirm:
+        password2 = getpass.getpass("Confirm: ")
+        if password != password2:
+            sys.exit("Error: Passwords do not match.")
+    if not password:
+        password = None
+    return password
+
+
+def init_cmdline(config_options, wallet_path, server, *, config: 'SimpleConfig'):
+    cmdname = config.get('cmd')
+    cmd = known_commands[cmdname]
+
+    if cmdname in ['payto', 'paytomany'] and config.get('unsigned'):
+        cmd.requires_password = False
+
+    if cmdname in ['payto', 'paytomany'] and config.get('broadcast'):
+        cmd.requires_network = True
+
+    # instantiate wallet for command-line
+    storage = WalletStorage(wallet_path)
+
+    if cmd.requires_wallet and not storage.file_exists():
+        print_msg("Error: Wallet file not found.")
+        print_msg("Type 'electrum-mars create' to create a new wallet, or provide a path to a wallet with the -w option")
+        sys_exit(1)
+
+    # important warning
+    if cmd.name in ['getprivatekeys']:
+        print_stderr("WARNING: ALL your private keys are secret.")
+        print_stderr("Exposing a single private key can compromise your entire wallet!")
+        print_stderr("In particular, DO NOT use 'redeem private key' services proposed by third parties.")
+
+    # will we need a password
+    if not storage.is_encrypted():
+        db = WalletDB(storage.read(), manual_upgrades=False)
+        use_encryption = db.get('use_encryption')
+    else:
+        use_encryption = True
+
+    # commands needing password
+    if ((cmd.requires_wallet and storage.is_encrypted() and server is False)\
+       or (cmdname == 'load_wallet' and storage.is_encrypted())\
+       or (cmd.requires_password and use_encryption)):
+        if storage.is_encrypted_with_hw_device():
+            # this case is handled later in the control flow
+            password = None
+        elif config.get('password'):
+            password = config.get('password')
+        else:
+            password = prompt_password('Password:', False)
+            if not password:
+                print_msg("Error: Password required")
+                sys_exit(1)
+    else:
+        password = None
+
+    config_options['password'] = config_options.get('password') or password
+
+    if cmd.name == 'password' and 'new_password' not in config_options:
+        new_password = prompt_password('New password:')
+        config_options['new_password'] = new_password
+
+
+def get_connected_hw_devices(plugins: 'Plugins'):
+    supported_plugins = plugins.get_hardware_support()
+    # scan devices
+    devices = []
+    devmgr = plugins.device_manager
+    for splugin in supported_plugins:
+        name, plugin = splugin.name, splugin.plugin
+        if not plugin:
+            e = splugin.exception
+            _logger.error(f"{name}: error during plugin init: {repr(e)}")
+            continue
+        try:
+            u = devmgr.unpaired_device_infos(None, plugin)
+        except Exception as e:
+            _logger.error(f'error getting device infos for {name}: {repr(e)}')
+            continue
+        devices += list(map(lambda x: (name, x), u))
+    return devices
+
+
+def get_password_for_hw_device_encrypted_storage(plugins: 'Plugins') -> str:
+    devices = get_connected_hw_devices(plugins)
+    if len(devices) == 0:
+        print_msg("Error: No connected hw device found. Cannot decrypt this wallet.")
+        sys.exit(1)
+    elif len(devices) > 1:
+        print_msg("Warning: multiple hardware devices detected. "
+                  "The first one will be used to decrypt the wallet.")
+    # FIXME we use the "first" device, in case of multiple ones
+    name, device_info = devices[0]
+    devmgr = plugins.device_manager
+    try:
+        client = devmgr.client_by_id(device_info.device.id_)
+        return client.get_password_for_storage_encryption()
+    except UserCancelled:
+        sys.exit(0)
+
+
+async def run_offline_command(config, config_options, plugins: 'Plugins'):
+    cmdname = config.get('cmd')
+    cmd = known_commands[cmdname]
+    password = config_options.get('password')
+    if 'wallet_path' in cmd.options and config_options.get('wallet_path') is None:
+        config_options['wallet_path'] = config.get_wallet_path()
+    if cmd.requires_wallet:
+        storage = WalletStorage(config.get_wallet_path())
+        if storage.is_encrypted():
+            if storage.is_encrypted_with_hw_device():
+                password = get_password_for_hw_device_encrypted_storage(plugins)
+                config_options['password'] = password
+            storage.decrypt(password)
+        db = WalletDB(storage.read(), manual_upgrades=False)
+        wallet = Wallet(db, storage, config=config)
+        config_options['wallet'] = wallet
+    else:
+        wallet = None
+    # check password
+    if cmd.requires_password and wallet.has_password():
+        try:
+            wallet.check_password(password)
+        except InvalidPassword:
+            print_msg("Error: This password does not decode this wallet.")
+            sys.exit(1)
+    if cmd.requires_network:
+        print_msg("Warning: running command offline")
+    # arguments passed to function
+    args = [config.get(x) for x in cmd.params]
+    # decode json arguments
+    if cmdname not in ('setconfig',):
+        args = list(map(json_decode, args))
+    # options
+    kwargs = {}
+    for x in cmd.options:
+        kwargs[x] = (config_options.get(x) if x in ['wallet_path', 'wallet', 'password', 'new_password'] else config.get(x))
+    cmd_runner = Commands(config=config)
+    func = getattr(cmd_runner, cmd.name)
+    result = await func(*args, **kwargs)
+    # save wallet
+    if wallet:
+        wallet.save_db()
+    return result
+
+
+def init_plugins(config, gui_name):
+    from electrum_mars.plugin import Plugins
+    return Plugins(config, gui_name)
+
+
+loop = None  # type: Optional[asyncio.AbstractEventLoop]
+stop_loop = None  # type: Optional[asyncio.Future]
+loop_thread = None  # type: Optional[threading.Thread]
+
+def sys_exit(i):
+    # stop event loop and exit
+    if loop:
+        loop.call_soon_threadsafe(stop_loop.set_result, 1)
+        loop_thread.join(timeout=1)
+    sys.exit(i)
+
+
+def main():
+    # The hook will only be used in the Qt GUI right now
+    util.setup_thread_excepthook()
+    # on macOS, delete Process Serial Number arg generated for apps launched in Finder
+    sys.argv = list(filter(lambda x: not x.startswith('-psn'), sys.argv))
+
+    # old 'help' syntax
+    if len(sys.argv) > 1 and sys.argv[1] == 'help':
+        sys.argv.remove('help')
+        sys.argv.append('-h')
+
+    # old '-v' syntax
+    # Due to this workaround that keeps old -v working,
+    # more advanced usages of -v need to use '-v='.
+    # e.g. -v=debug,network=warning,interface=error
+    try:
+        i = sys.argv.index('-v')
+    except ValueError:
+        pass
+    else:
+        sys.argv[i] = '-v*'
+
+    # read arguments from stdin pipe and prompt
+    for i, arg in enumerate(sys.argv):
+        if arg == '-':
+            if not sys.stdin.isatty():
+                sys.argv[i] = sys.stdin.read()
+                break
+            else:
+                raise Exception('Cannot get argument from stdin')
+        elif arg == '?':
+            sys.argv[i] = input("Enter argument:")
+        elif arg == ':':
+            sys.argv[i] = prompt_password('Enter argument (will not echo):', False)
+
+    # parse command line
+    parser = get_parser()
+    args = parser.parse_args()
+
+    # config is an object passed to the various constructors (wallet, interface, gui)
+    if is_android:
+        import importlib.util
+        android_gui = 'kivy' if importlib.util.find_spec('kivy') else 'qml'
+        config_options = {
+            'verbosity': '*' if util.is_android_debug_apk() else '',
+            'cmd': 'gui',
+            'gui': android_gui,
+            'single_password': True,
+        }
+        if util.get_android_package_name() == "org.electrum_mars.testnet.electrum_mars":
+            # ~hack for easier testnet builds. pkgname subject to change.
+            config_options['testnet'] = True
+    else:
+        config_options = args.__dict__
+        f = lambda key: config_options[key] is not None and key not in config_variables.get(args.cmd, {}).keys()
+        config_options = {key: config_options[key] for key in filter(f, config_options.keys())}
+        if config_options.get('server'):
+            config_options['auto_connect'] = False
+
+    config_options['cwd'] = cwd = os.getcwd()
+
+    # fixme: this can probably be achieved with a runtime hook (pyinstaller)
+    if is_pyinstaller and os.path.exists(os.path.join(sys._MEIPASS, 'is_portable')):
+        config_options['portable'] = True
+
+    if config_options.get('portable'):
+        if is_local:
+            # running from git clone or local source: put datadir next to main script
+            datadir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'electrum-mars_data')
+        else:
+            # Running a binary or installed source. The most generic but still reasonable thing
+            # is to use the current working directory. (see #7732)
+            # note: The main script is often unpacked to a temporary directory from a bundled executable,
+            #       and we don't want to put the datadir inside a temp dir.
+            # note: Re the portable .exe on Windows, when the user double-clicks it, CWD gets set
+            #       to the parent dir, i.e. we will put the datadir next to the exe.
+            datadir = os.path.join(os.path.realpath(cwd), 'electrum-mars_data')
+        config_options['electrum_path'] = datadir
+
+    if not config_options.get('verbosity'):
+        warnings.simplefilter('ignore', DeprecationWarning)
+
+    # check uri
+    uri = config_options.get('url')
+    if uri and not util.is_uri(uri):
+        print_stderr('unknown command:', uri)
+        sys.exit(1)
+
+    config = SimpleConfig(config_options)
+
+    # set language as early as possible
+    # Note: we are already too late for strings that are declared in the global scope
+    #       of an already imported module. However, the GUI and the plugins at least have
+    #       not been imported yet.
+    # Note: it is ok to call set_language() again later. E.g. the Qt GUI has additional
+    #       tools to figure out the default language so it will get called again there.
+    set_language(config.get('language'))
+
+    if config.get('testnet'):
+        constants.set_testnet()
+    elif config.get('regtest'):
+        constants.set_regtest()
+    elif config.get('simnet'):
+        constants.set_simnet()
+    elif config.get('signet'):
+        constants.set_signet()
+
+    cmdname = config.get('cmd')
+
+    if cmdname == 'daemon' and config.get("detach"):
+        # fork before creating the asyncio event loop
+        pid = os.fork()
+        if pid:
+            print_stderr("starting daemon (PID %d)" % pid)
+            sys.exit(0)
+        else:
+            # redirect standard file descriptors
+            sys.stdout.flush()
+            sys.stderr.flush()
+            si = open(os.devnull, 'r')
+            so = open(os.devnull, 'w')
+            se = open(os.devnull, 'w')
+            os.dup2(si.fileno(), sys.stdin.fileno())
+            os.dup2(so.fileno(), sys.stdout.fileno())
+            os.dup2(se.fileno(), sys.stderr.fileno())
+
+    global loop, stop_loop, loop_thread
+    loop, stop_loop, loop_thread = create_and_start_event_loop()
+
+    try:
+        handle_cmd(
+            cmdname=cmdname,
+            config=config,
+            config_options=config_options,
+        )
+    except Exception:
+        _logger.exception("")
+        sys_exit(1)
+
+
+def handle_cmd(*, cmdname: str, config: 'SimpleConfig', config_options: dict):
+    if cmdname == 'gui':
+        configure_logging(config)
+        fd = daemon.get_file_descriptor(config)
+        if fd is not None:
+            plugins = init_plugins(config, config.get('gui', 'qt'))
+            d = daemon.Daemon(config, fd)
+            try:
+                d.run_gui(config, plugins)
+            except BaseException as e:
+                _logger.exception('daemon.run_gui errored')
+                sys_exit(1)
+            else:
+                sys_exit(0)
+        else:
+            result = daemon.request(config, 'gui', (config_options,))
+
+    elif cmdname == 'daemon':
+
+        configure_logging(config)
+        fd = daemon.get_file_descriptor(config)
+        if fd is not None:
+            # run daemon
+            init_plugins(config, 'cmdline')
+            d = daemon.Daemon(config, fd)
+            d.run_daemon()
+            sys_exit(0)
+        else:
+            # FIXME this message is lost in detached mode (parent process already exited after forking)
+            print_msg("Daemon already running")
+            sys_exit(1)
+    else:
+        # command line
+        configure_logging(config, log_to_file=False)  # don't spam logfiles for each client-side RPC, but support "-v"
+        cmd = known_commands[cmdname]
+        wallet_path = config.get_wallet_path()
+        if not config.get('offline'):
+            init_cmdline(config_options, wallet_path, True, config=config)
+            timeout = config.get('timeout', 60)
+            if timeout: timeout = int(timeout)
+            try:
+                result = daemon.request(config, 'run_cmdline', (config_options,), timeout)
+            except daemon.DaemonNotRunning:
+                print_msg("Daemon not running; try 'electrum-mars daemon -d'")
+                if not cmd.requires_network:
+                    print_msg("To run this command without a daemon, use --offline")
+                sys_exit(1)
+            except Exception as e:
+                print_stderr(str(e) or repr(e))
+                sys_exit(1)
+        else:
+            if cmd.requires_network:
+                print_msg("This command cannot be run offline")
+                sys_exit(1)
+            init_cmdline(config_options, wallet_path, False, config=config)
+            plugins = init_plugins(config, 'cmdline')
+            coro = run_offline_command(config, config_options, plugins)
+            fut = asyncio.run_coroutine_threadsafe(coro, loop)
+            try:
+                result = fut.result()
+            except Exception as e:
+                print_stderr(str(e) or repr(e))
+                sys_exit(1)
+    if isinstance(result, str):
+        print_msg(result)
+    elif type(result) is dict and result.get('error'):
+        print_stderr(result.get('error'))
+        sys_exit(1)
+    elif result is not None:
+        print_msg(json_encode(result))
+    sys_exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/electrum_mars/version.py
+++ b/electrum_mars/version.py
@@ -1,4 +1,4 @@
-ELECTRUM_VERSION = '4.3.2.0-mars'  # version of the client package
+ELECTRUM_VERSION = '4.3.2.0+mars'  # version of the client package
 APK_VERSION = '4.3.2.0'             # read by buildozer.spec
 
 PROTOCOL_VERSION = '1.4'     # protocol version requested


### PR DESCRIPTION
## Summary
- **version.py**: `4.3.2.0-mars` → `4.3.2.0+mars` — the hyphen syntax is not PEP 440 compliant, causing modern pip/setuptools to reject the build. The `+` local version identifier is the correct form.
- **MANIFEST.in**: Updated all `electrum_ltc` → `electrum_mars` and `electrum-ltc.desktop` → `electrum-mars.desktop` references left over from the Litecoin fork.
- **electrum_mars/electrum-mars**: Added the missing script file that `setup.py` references in `scripts=[]`. Only `electrum-ltc` existed.

Without these fixes, `pip install -e ".[crypto]"` fails on any modern Python/setuptools.

## Test plan
- [ ] `pip install -e ".[crypto]"` completes without errors
- [ ] `python run_electrum --help` shows usage
- [ ] `python run_electrum` launches the Qt GUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)